### PR TITLE
make rust existing condition more exact for this script

### DIFF
--- a/install-rust-toolchain.sh
+++ b/install-rust-toolchain.sh
@@ -79,7 +79,7 @@ set -e
 #set -v
 
 # Check required tooling - rustc, rustfmt
-which rustup || install_rust
+command -v rustup || install_rust
 rustup toolchain list | grep nightly || install_rust_nightly
 rustfmt --version | grep stable || install_rustfmt
 


### PR DESCRIPTION
... because `rustup` is more general thing.

It fixes configurations (Fedora) where rustc gets installed without rustup.

Also let me use the POSIX command `command -v` instead of 'which"