### PR TITLE
Workflow changes for running on native github runners

### DIFF
--- a/.github/actions/build/build-rust-std/action.yaml
+++ b/.github/actions/build/build-rust-std/action.yaml
@@ -1,0 +1,58 @@
+name: 'Build Ruststd'
+description: 'Build the rust std Library'
+
+runs:
+  using: "composite"
+  steps:
+
+    # Run the Windows Build using powershell
+
+    - name: Prepare build
+      if: startsWith(matrix.os, 'windows')
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --enable-extended --dist-compression-formats='xz'
+
+    - name: Build with x.py - Standard Library
+      if: startsWith(matrix.os, 'windows')
+      # Note excluding src/doc breaks build of 1.55
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      run: python3 x.py build --exclude src/doc --stage 2 library/std
+
+    - name: Dist with x.py - Standard Library
+      if: startsWith(matrix.os, 'windows')
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      run: python3 x.py dist --stage 2 library/std
+
+
+    # Run Linux builds using bash
+
+    - name: Prepare build
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --enable-extended --dist-compression-formats='xz'
+
+    - name: Build with x.py - Standard Library
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      # Note excluding src/doc breaks build of 1.55
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 x.py build --exclude src/doc --stage 2 library/std
+
+    - name: Dist with x.py - Standard Library
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 x.py dist --stage 2 library/std
+
+
+    # Save the result
+
+    - name: Save Artifact - Standard Library
+      uses: actions/upload-artifact@v2
+      with:
+        name: rust-std-${{ env.build_suffix }}.tar.xz
+        path: ${{ env.dist_dir }}/rust-std-${{ env.build_suffix }}.tar.xz

--- a/.github/actions/build/build-rustc/action.yaml
+++ b/.github/actions/build/build-rustc/action.yaml
@@ -1,0 +1,58 @@
+name: 'Build Rustc'
+description: 'Build the rustc toolchain'
+
+runs:
+  using: "composite"
+  steps:
+
+    # Run the Windows Build using powershell
+
+    - name: Prepare build
+      if: startsWith(matrix.os, 'windows')
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --enable-extended --dist-compression-formats='xz'
+
+    - name: Build with x.py - Compiler
+      if: startsWith(matrix.os, 'windows')
+      # Note excluding src/doc breaks build of 1.55
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      run: python3 x.py build --exclude src/doc --stage 2 compiler/rustc
+
+    - name: Dist with x.py - Compiler
+      if: startsWith(matrix.os, 'windows')
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      run: python3 x.py dist --stage 2 src/librustc
+
+
+    # Run Linux builds using bash
+
+    - name: Prepare build
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --enable-extended --dist-compression-formats='xz'
+
+    - name: Build with x.py - Compiler
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      # Note excluding src/doc breaks build of 1.55
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 x.py build --exclude src/doc --stage 2 compiler/rustc
+
+    - name: Dist with x.py - Compiler
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 x.py dist --stage 2 src/librustc
+
+
+    # Save the result
+
+    - name: Save Artifact - Rustc
+      uses: actions/upload-artifact@v2
+      with:
+        name: rustc-${{ env.build_suffix }}.tar.xz
+        path: ${{ env.dist_dir }}/rustc-${{ env.build_suffix }}.tar.xz

--- a/.github/actions/build/build-src/action.yaml
+++ b/.github/actions/build/build-src/action.yaml
@@ -1,0 +1,44 @@
+name: 'Build Src'
+description: 'Build the rustc src'
+
+runs:
+  using: "composite"
+  steps:
+
+    # Run the Windows Build using powershell
+
+    - name: Prepare build - Windows
+      if: startsWith(matrix.os, 'windows')
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --enable-extended --tools=rustfmt,cargo --dist-compression-formats='xz'
+
+    - name: Dist with x.py - Src - Windows
+      if: startsWith(matrix.os, 'windows')
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      run: python3 x.py dist --stage 2 src
+
+
+    # Run Linux builds using bash
+
+    - name: Prepare build - Unix
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --enable-extended --tools=rustfmt,cargo --dist-compression-formats='xz'
+
+    - name: Dist with x.py - Src - Unix
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 x.py dist --stage 2 src
+
+
+    # Save the result
+
+    - name: Save Artifact - Src
+      uses: actions/upload-artifact@v2
+      with:
+        name: rust-src-${{ env.rust_ver }}-dev.tar.xz
+        path: ${{ env.dist_dir }}/rust-src-${{ env.rust_ver }}-dev.tar.xz

--- a/.github/actions/build/build-tools/action.yaml
+++ b/.github/actions/build/build-tools/action.yaml
@@ -1,0 +1,69 @@
+name: 'Build Tools'
+description: 'Build the rustc tools'
+
+runs:
+  using: "composite"
+  steps:
+
+    # Run the Windows Build using powershell
+
+    - name: Prepare build
+      if: startsWith(matrix.os, 'windows')
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --enable-extended --tools=rustfmt,cargo --dist-compression-formats='xz'
+
+    - name: Build with x.py - Tools
+      if: startsWith(matrix.os, 'windows')
+      # Note excluding src/doc breaks build of 1.55
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      # We only want to do cargo for windows builds
+      run: python3 x.py build --exclude src/doc --stage 2 src/tools/rustfmt src/tools/cargo
+
+    - name: Dist with x.py - Tools
+      if: startsWith(matrix.os, 'windows')
+      # We include cargo to get around https://github.com/esp-rs/rust-build/issues/17
+      working-directory: ${{ env.work_dir }}
+      shell: pwsh
+      run: python3 x.py dist --stage 2 rustfmt cargo
+
+
+    # Run Linux builds using bash
+
+    - name: Prepare build
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --enable-extended --tools=rustfmt,cargo --dist-compression-formats='xz'
+
+    - name: Build with x.py - Tools
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      # Note excluding src/doc breaks build of 1.55
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 x.py build --exclude src/doc --stage 2 src/tools/rustfmt
+
+    - name: Dist with x.py - Tools
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      # We include cargo to get around https://github.com/esp-rs/rust-build/issues/17
+      working-directory: ${{ env.work_dir }}
+      shell: bash
+      run: python3 x.py dist --stage 2 rustfmt cargo
+
+
+    # Save the result
+
+    # We only want to do cargo for windows builds
+    - name: Save Artifact - Cargo
+      if: startsWith(matrix.os, 'windows')
+      uses: actions/upload-artifact@v2
+      with:
+        name: cargo-${{ env.build_suffix }}.tar.xz
+        path: ${{ env.dist_dir }}/cargo-${{ env.build_suffix }}.tar.xz
+
+    - name: Save Artifact - RustFmt
+      uses: actions/upload-artifact@v2
+      with:
+        name: rustfmt-${{ env.build_suffix }}.tar.xz
+        path: ${{ env.dist_dir }}/rustfmt-${{ env.build_suffix }}.tar.xz

--- a/.github/actions/tools/setup-libudev/action.yaml
+++ b/.github/actions/tools/setup-libudev/action.yaml
@@ -1,0 +1,12 @@
+name: 'Setup libudev-dev'
+description: 'Install libudev-dev'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Install libudev-dev
+      if: startsWith(matrix.os, 'ubuntu')
+      shell: bash
+      run: |
+        sudo apt-get install -y libudev-dev

--- a/.github/actions/tools/setup-ninja/action.yaml
+++ b/.github/actions/tools/setup-ninja/action.yaml
@@ -1,0 +1,9 @@
+name: 'Setup Ninja'
+description: 'Setup the Ninja Build System'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Setup Ninja
+      uses: seanmiddleditch/gha-setup-ninja@master

--- a/.github/actions/tools/setup-python/action.yaml
+++ b/.github/actions/tools/setup-python/action.yaml
@@ -1,0 +1,11 @@
+name: 'Setup Python'
+description: 'Setup the Python Install'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'

--- a/.github/actions/util/checkout-esp-rust/action.yaml
+++ b/.github/actions/util/checkout-esp-rust/action.yaml
@@ -1,0 +1,14 @@
+name: 'Checkout Source'
+description: 'Downloads the Source for esp-rs/rust'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        repository: esp-rs/rust
+        ref: esp-${{ env.rust_ver }}
+        submodules: true
+        path: "rust"

--- a/.github/actions/util/create-archive/action.yaml
+++ b/.github/actions/util/create-archive/action.yaml
@@ -1,0 +1,80 @@
+name: 'Create Archive'
+description: 'Create a release archive for upload'
+
+# To avoid disk space issues under github workflow
+# we need to split the build into multiple jobs
+
+# running x.py dist during the build generates a .tar.xz file
+# (Note cp -r from stage2 is dangerous, because there is a src symlink to parent project dir which causes recursion)
+# We take each of these from each build job and combine them into one here
+
+# Typically the final archive with the toolchain and tools should be extracted to
+# ~/.rustup/toolchains.
+
+runs:
+  using: "composite"
+  steps:
+
+    # Read in the built files
+    - uses: ./rust-build/.github/actions/util/read-artifacts
+
+    # Create Archive - Windows zip
+    - name: Create Archive - Windows (Zip)
+      if: startsWith(matrix.os, 'windows')
+      shell: bash
+      run: |
+
+        mkdir esp
+
+        # Copy in rust-std
+        tar -xvf ./rust-std-${{ env.build_suffix }}.tar.xz
+        cp -af ./rust-std-${{ env.build_suffix }}/rust-std-${{ matrix.target_name }}/* ./esp/
+
+        # Copy in the cargo tool
+        tar -xvf ./cargo-${{ env.build_suffix }}.tar.xz
+        cp -af ./cargo-${{ env.build_suffix }}/cargo/* ./esp/
+
+        # Copy in the rustfmt tool
+        tar -xvf ./rustfmt-${{ env.build_suffix }}.tar.xz
+        cp -af ./rustfmt-${{ env.build_suffix }}/rustfmt-preview/* ./esp/
+
+        # Copy in the rust-src content
+        tar -xvf ./rust-src-${{ env.rust_ver }}-dev.tar.xz
+        cp -af ./rust-src-${{ env.rust_ver }}-dev/rust-src/* ./esp/
+
+        # Copy in the rustc content
+        tar -xvf ./rustc-${{ env.build_suffix }}.tar.xz
+        cp -af ./rustc-${{ env.build_suffix }}/rustc/* ./esp/
+
+        # Build the final zip
+        7z a ${{ env.asset_name }} esp/
+
+
+    # Create Archive - Linux tar.xz
+    - name: Create Archive - Linux (tar.xz)
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      shell: bash
+      run: |
+
+        mkdir ${{ env.archive_dir }}
+
+        # Copy in rust-std
+        tar -xvf ./rust-std-${{ env.build_suffix }}.tar.xz
+        cp -af ./rust-std-${{ env.build_suffix }}/* ./${{ env.archive_dir }}/
+
+        # Copy in the rustfmt tool
+        tar -xvf ./rustfmt-${{ env.build_suffix }}.tar.xz
+        cp -af ./rustfmt-${{ env.build_suffix }}/* ./${{ env.archive_dir }}/
+
+        # Copy in the rustc content
+        tar -xvf ./rustc-${{ env.build_suffix }}.tar.xz
+        cp -af ./rustc-${{ env.build_suffix }}/* ./${{ env.archive_dir }}/
+
+        # At this stage the components file will just contain "rustc"
+        # As this is the last one copied in
+        # Make sure the other components are recognised by the install script
+        echo "rust-std-${{ matrix.target_name }}" >> ./${{ env.archive_dir }}/components
+        echo "rustfmt-preview" >> ./${{ env.archive_dir }}/components
+
+        # Build the final tar
+        tar -cJf ${{ env.asset_name }} ${{ env.archive_dir }}

--- a/.github/actions/util/read-artifacts/action.yaml
+++ b/.github/actions/util/read-artifacts/action.yaml
@@ -15,15 +15,16 @@ runs:
       with: 
         name: rust-std-${{ env.build_suffix }}.tar.xz
 
-    - name: Read Artifact - Cargo
-      uses: actions/download-artifact@v2
-      with: 
-        name: cargo-${{ env.build_suffix }}.tar.xz
-
     - name: Read Artifact - RustFmt
       uses: actions/download-artifact@v2
       with: 
         name: rustfmt-${{ env.build_suffix }}.tar.xz
+
+    - name: Read Artifact - Cargo
+      if: startsWith(matrix.os, 'windows')
+      uses: actions/download-artifact@v2
+      with: 
+        name: cargo-${{ env.build_suffix }}.tar.xz
 
     - name: Read Artifact - Src
       if: startsWith(matrix.os, 'windows')

--- a/.github/actions/util/read-artifacts/action.yaml
+++ b/.github/actions/util/read-artifacts/action.yaml
@@ -1,0 +1,32 @@
+name: 'Read Cache'
+description: 'Reads in all of the built artifact files prior to create-archive'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Read Artifact - Rustc
+      uses: actions/download-artifact@v2
+      with: 
+        name: rustc-${{ env.build_suffix }}.tar.xz
+
+    - name: Read Artifact - Standard Library
+      uses: actions/download-artifact@v2
+      with: 
+        name: rust-std-${{ env.build_suffix }}.tar.xz
+
+    - name: Read Artifact - Cargo
+      uses: actions/download-artifact@v2
+      with: 
+        name: cargo-${{ env.build_suffix }}.tar.xz
+
+    - name: Read Artifact - RustFmt
+      uses: actions/download-artifact@v2
+      with: 
+        name: rustfmt-${{ env.build_suffix }}.tar.xz
+
+    - name: Read Artifact - Src
+      if: startsWith(matrix.os, 'windows')
+      uses: actions/download-artifact@v2
+      with: 
+        name: rust-src-${{ env.rust_ver }}-dev.tar.xz

--- a/.github/actions/util/setup-envs/action.yaml
+++ b/.github/actions/util/setup-envs/action.yaml
@@ -1,0 +1,78 @@
+name: 'Setup Env Variables - Rust Build'
+description: 'Setup Env Variables - Rust Build'
+
+# used for rust build
+
+inputs:
+  github_token:
+    # We can't use secrets directly in composite workflows
+    description: "Github secret token"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Setup Env Variables - Common
+      shell: bash
+      run: |
+
+        # Set the github token as an env variable for use with uploads
+        echo "GITHUB_TOKEN=${{ inputs.github_token }}" >> $GITHUB_ENV
+
+        # esp rust version to checkout
+        echo "rust_ver=${{ github.event.inputs.rust_ver }}" >> $GITHUB_ENV
+
+        # Describes part of the file name generated during the build 
+        echo "build_suffix=${{ github.event.inputs.rust_ver }}-dev-${{ matrix.target_name }}" >> $GITHUB_ENV
+
+        # release version
+        echo "release_ver=${{ github.event.inputs.release_ver }}" >> $GITHUB_ENV
+
+        # release version
+        echo "archive_dir=rust-${{ github.event.inputs.rust_ver }}-dev-${{ matrix.target_name }}" >> $GITHUB_ENV
+
+    - name: Setup Env Variables - Windows
+      if: startsWith(matrix.os, 'windows')
+      shell: bash
+      run: |
+
+        # Working / Source direcory for Windows
+        # Symlinked to get around long path issues
+        echo "work_dir=D:/rust" >> $GITHUB_ENV
+
+        # The dist dir is where the final archives are stored during the build
+        echo "dist_dir=D:/rust/build/dist" >> $GITHUB_ENV
+
+        # asset name for release
+        echo "asset_name=rust-${{ github.event.inputs.release_ver }}-${{ matrix.target_name }}.zip" >> $GITHUB_ENV
+
+
+    - name: Setup Env Variables - Unix
+      if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      shell: bash
+      run: |
+
+        # Working / Source direcory for Windows
+        # Symlinked to get around long path issues
+        echo "work_dir=${{ github.workspace }}/rust" >> $GITHUB_ENV
+
+        # The dist dir is where the final archives are stored during the build
+        echo "dist_dir=${{ github.workspace }}/rust/build/dist" >> $GITHUB_ENV
+
+        # asset name for release
+        echo "asset_name=rust-${{ github.event.inputs.release_ver }}-${{ matrix.target_name }}.tar.xz" >> $GITHUB_ENV
+
+        # Fixes issues when trying to do a dist with the src
+        mkdir -p ${{ github.workspace }}/.cache/cargo
+        echo "CARGO_HOME=${{ github.workspace }}/.cache/cargo" >> $GITHUB_ENV
+
+#    - name: Debug Output Env Variables
+#      shell: bash
+#      run: |
+#        echo "rust_ver: ${{ env.rust_ver }}"
+#        echo "build_suffix: ${{ env.build_suffix }}"
+#        echo "release_ver: ${{ env.release_ver }}"
+#        echo "asset_name: ${{ env.asset_name }}"
+#        echo "work_dir: ${{ env.work_dir }}"
+#        echo "dist_dir: ${{ env.dist_dir }}"

--- a/.github/actions/util/symlink-working-dir/action.yaml
+++ b/.github/actions/util/symlink-working-dir/action.yaml
@@ -1,0 +1,15 @@
+name: 'SymLink the working directory'
+description: 'SymLink the working directory'
+
+runs:
+  using: "composite"
+  steps:
+
+      # Windows typically can have long path issues
+      # To get around this we create a link
+      # from D:/a/rust-build/rust-build/rust to D:/rust to shorten the build path
+
+    - name: Symlink working directory
+      shell: pwsh
+      if: startsWith(matrix.os, 'windows')
+      run: New-Item -Path ${{ env.work_dir }} -ItemType SymbolicLink -Value ${{ github.workspace }}/rust

--- a/.github/actions/util/upload/action.yaml
+++ b/.github/actions/util/upload/action.yaml
@@ -1,0 +1,21 @@
+name: 'Upload to github releases'
+description: 'Upload the final built archive to github'
+
+# In addition to uploading the file to the release
+# * This also turns a tag into a release if one doesn't exist already
+# * doesn't fail if the file is already uploaded to the release
+# * Is a lot simpler than upload-release-asset
+# * Seems to be more actively maintained
+# * Doesn't require the use of octokit/request-action@v2.x / get latest release
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Upload Release Asset
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name:
+          v${{ env.release_ver }}
+        files:
+          ${{ env.asset_name }}

--- a/.github/workflows/build-rust-src-dispatch.yaml
+++ b/.github/workflows/build-rust-src-dispatch.yaml
@@ -1,0 +1,82 @@
+name: Build src
+
+on:
+  workflow_dispatch:
+    inputs:
+      rust_build_branch:
+        description: 'Branch of rust-build to use'
+        required: true
+        default: 'main'
+      release_ver:
+        description: 'Release Version for generation'
+        required: true
+        default: '1.56.0.1'
+      rust_ver:
+        description: 'Version of esp rust to use'
+        required: true
+        default: '1.56.0'
+
+
+jobs:
+
+  build-src:
+    name: Build (idf) rust src for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        include:
+
+        - os: macos-latest
+          target_name: x86_64-apple-darwin
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/tools/setup-python
+      - uses: ./rust-build/.github/actions/tools/setup-ninja
+      - uses: ./rust-build/.github/actions/util/checkout-esp-rust
+      - uses: ./rust-build/.github/actions/util/symlink-working-dir
+      - uses: ./rust-build/.github/actions/build/build-src
+
+
+  upload-archive:
+    name: Upload (idf) rust src
+    needs: [build-src]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        include:
+
+        - os: macos-latest
+          target_name: x86_64-apple-darwin
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read Artifact - Src
+        uses: actions/download-artifact@v2
+        with: 
+          name: rust-src-${{ env.rust_ver }}-dev.tar.xz
+
+      - name: Rename file
+        shell: bash
+        run: |
+          mv rust-src-${{ env.rust_ver }}-dev.tar.xz rust-src-${{ env.release_ver }}.tar.xz
+          echo "asset_name=rust-src-${{ env.release_ver }}.tar.xz" >> $GITHUB_ENV
+
+      - uses: ./rust-build/.github/actions/util/upload

--- a/.github/workflows/build-rust-x86_64-apple-darwin-dispatch.yaml
+++ b/.github/workflows/build-rust-x86_64-apple-darwin-dispatch.yaml
@@ -1,94 +1,103 @@
-name: build-rust-macos-x64-dispatch
+name: Build macos-latest (darwin) x86_64
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      rust_build_branch:
+        description: 'Branch of rust-build to use'
+        required: true
+        default: 'main'
+      release_ver:
+        description: 'Release Version for generation'
+        required: true
+        default: '1.56.0.1'
+      rust_ver:
+        description: 'Version of esp rust to use'
+        required: true
+        default: '1.56.0'
 
+
+# We Break this down into individual jobs to avoid disk space issues
 jobs:
-  get_release:
-    # https://github.com/octokit/request-action
-    name: Get release
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.get_upload_url.outputs.url }}
-    steps:
-    - uses: octokit/request-action@v2.x
-      id: get_latest_release
-      with:
-        route: GET /repos/{owner}/{repo}/releases/latest
-        owner: esp-rs
-        repo: rust-build
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: get upload url
-      id: get_upload_url
-      run: |
-        url=$(echo "$response" | jq -r '.upload_url')
-        echo "::set-output name=url::$url"
-      env:
-        response:  ${{ steps.get_latest_release.outputs.data }}
 
-  build-idf-rust:
-    name: Build IDF Rust for ${{ matrix.os }}
-    # needs: create_release
-    needs: get_release
+  build-rustc:
+    # Build the compiler / std library
+    name: Build (idf) rustc/std for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest]
         include:
-        - os: macos-latest
-          ARCH: ''
-          TARGET: macos-x64
-          ASSET_PATH: 'build/dist/rust-1.56.0-dev-x86_64-apple-darwin.tar.xz'
-          ASSET_NAME: 'rust-1.56.0.1-dev-x86_64-apple-darwin.tar.xz'
-          ASSET_CONTENT_TYPE: 'application/x-tar'
-          LLVM_ROOT_OPTION: ''
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          repository: esp-rs/rust
-          ref: esp-1.56.0
-          submodules: true
-      - name: Set up Python
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - name: Setup Ninja
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: seanmiddleditch/gha-setup-ninja@master
-      - name: Prepare build
-        run: python3 src/bootstrap/configure.py ${{ matrix.LLVM_ROOT_OPTION }} --experimental-targets=Xtensa --enable-extended --tools=rustfmt --dist-compression-formats='xz'
-      - name: Build with x.py - only components
-        if: ${{ matrix.os == 'windows-self-hosted' }}
-        run: |
-          python3 x.py build compiler/rustc src/tools/rustfmt library/std --stage 2
-          python3 x.py dist src --stage 2
-      - name: Build with x.py - dist packages - continue on error - macOS pgk problem
-        if: ${{ matrix.os == 'macos-latest' }}
-        continue-on-error: true
-        run: python3 x.py dist --stage 2
-      - name: Build with x.py - dist packages
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' }}
-        run: python3 x.py dist --stage 2
-        # Excluding src/doc breaks build of 1.55
-        #run: python3 x.py dist --stage 2 --exclude src/doc
-      - name: Build with x.py - dist packages - continue on error - problem with Long path on Windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        continue-on-error: true
-        run: python3 x.py dist --stage 2
-      - name: Build with x.py - dist packages - with cached LLVM
-        if: ${{ matrix.os == 'macos-m1-self-hosted' }}
-        run: python3 x.py dist --stage 2 --exclude src/doc --llvm-skip-rebuild TRUE
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.get_release.outputs.upload_url }}
-          asset_path: ${{ matrix.ASSET_PATH }}
-          asset_name: ${{ matrix.ASSET_NAME }}
-          asset_content_type: ${{ matrix.ASSET_CONTENT_TYPE }}
 
+        - os: macos-latest
+          target_name: x86_64-apple-darwin
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/tools/setup-python
+      - uses: ./rust-build/.github/actions/tools/setup-ninja
+      - uses: ./rust-build/.github/actions/util/checkout-esp-rust
+      - uses: ./rust-build/.github/actions/util/symlink-working-dir
+      - uses: ./rust-build/.github/actions/build/build-rustc
+      - uses: ./rust-build/.github/actions/build/build-rust-std
+
+
+  build-tools:
+    # Build the tools - cargo / rustfmt
+    name: Build (idf) rust tools for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        include:
+
+        - os: macos-latest
+          target_name: x86_64-apple-darwin
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/tools/setup-python
+      - uses: ./rust-build/.github/actions/tools/setup-ninja
+      - uses: ./rust-build/.github/actions/util/checkout-esp-rust
+      - uses: ./rust-build/.github/actions/util/symlink-working-dir
+      - uses: ./rust-build/.github/actions/build/build-tools
+
+
+  upload-archive:
+    # Uploads a merged archive
+    name: Upload (idf) rust release for ${{ matrix.os }}
+    needs: [build-rustc, build-tools]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        include:
+
+        - os: macos-latest
+          target_name: x86_64-apple-darwin
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/util/create-archive
+      - uses: ./rust-build/.github/actions/util/upload

--- a/.github/workflows/build-rust-x86_64-pc-windows-msvc-dispatch.yaml
+++ b/.github/workflows/build-rust-x86_64-pc-windows-msvc-dispatch.yaml
@@ -1,114 +1,131 @@
-name: build-rust-windows-dispatch
+name: Build windows-latest x86_64
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      rust_build_branch:
+        description: 'Branch of rust-build to use'
+        required: true
+        default: 'main'
+      release_ver:
+        description: 'Release Version for generation'
+        required: true
+        default: '1.56.0.1'
+      rust_ver:
+        description: 'Version of esp rust to use'
+        required: true
+        default: '1.56.0'
 
+
+# We Break this down into individual jobs to avoid disk space issues
 jobs:
-  get_release:
-    # https://github.com/octokit/request-action
-    name: Get release
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.get_upload_url.outputs.url }}
-    steps:
-    - uses: octokit/request-action@v2.x
-      id: get_latest_release
-      with:
-        route: GET /repos/{owner}/{repo}/releases/latest
-        owner: esp-rs
-        repo: rust-build
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: get upload url
-      id: get_upload_url
-      run: |
-        url=$(echo "$response" | jq -r '.upload_url')
-        echo "::set-output name=url::$url"
-      env:
-        response:  ${{ steps.get_latest_release.outputs.data }}
 
-  build-idf-rust:
-    name: Build IDF Rust for ${{ matrix.os }}
-    # needs: create_release
-    needs: get_release
+  build-rustc:
+    # Build the compiler / std library
+    name: Build (idf) rustc/std for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    env:
-      working-directory: D:/
     strategy:
       matrix:
         os: [windows-latest]
         include:
-        - os: windows-latest
-          ARCH: ''
-          TARGET: win-x64
-          ASSET_PATH: 'build/dist/esp.zip'
-          ASSET_NAME: 'rust-1.56.0.1-dev-x86_64-pc-windows-msvc.zip'
-          ASSET_CONTENT_TYPE: 'application/zip'
-          LLVM_ROOT_OPTION: ''
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          repository: esp-rs/rust
-          ref: esp-1.56.0
-          submodules: true
-      - name: Set up Python
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - name: Setup Ninja
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: seanmiddleditch/gha-setup-ninja@master
-      - name: Prepare build
-        working-directory: D:/rust
-        run: python3 src/bootstrap/configure.py ${{ matrix.LLVM_ROOT_OPTION }} --experimental-targets=Xtensa --enable-extended --tools=rustfmt --dist-compression-formats='xz'
-      - name: Build with x.py - only components
-        working-directory: D:/rust
-        if: ${{ matrix.os == 'windows-self-hosted' ||  matrix.os == 'windows-latest' }}
-        continue-on-error: true
-        run: python3 x.py dist --stage 2
-      - name: Build with x.py - dist packages
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' }}
-        run: python3 x.py dist --stage 2
-        # Excluding src/doc breaks build of 1.55
-        #run: python3 x.py dist --stage 2 --exclude src/doc
-      - name: Build with x.py - dist packages - with cached LLVM
-        if: ${{ matrix.os == 'macos-m1-self-hosted' }}
-        run: python3 x.py dist --stage 2 --exclude src/doc --llvm-skip-rebuild TRUE
-      - name: Dist bundle for Windows
-        working-directory: D:/rust/build/dist
-        # Windows build has several issues:
-        # - long path problem in version 1.56.0, build of some dist artifacts fails
-        # - cp -r from stage2 is dangerous, because there is a src symlink to parent project dir which causes recursion
-        # Following code is workaround which assembles minimal distribution of toolchain which should be extracted to ~/.rustup/toolchains.
-        if: ${{ matrix.os == 'windows-self-hosted' || matrix.os == 'windows-latest' }}
-        shell: pwsh
-        run: |
-          mkdir esp
-          7z e rust-1.56.0-dev-x86_64-pc-windows-msvc.tar.xz
-          7z x rust-1.56.0-dev-x86_64-pc-windows-msvc.tar
-          pushd rust-1.56.0-dev-x86_64-pc-windows-msvc
-          cp -Recurse .\rustc\bin ..\esp\
-          cp -Recurse .\rustc\lib ..\esp\
-          cp -Recurse .\rustc\share ..\esp\
-          cp -ErrorAction SilentlyContinue -Recurse .\rust-std-x86_64-pc-windows-msvc\lib\* ..\esp\lib\
-          popd
-          7z e rust-src-1.56.0-dev.tar.xz
-          7z x rust-src-1.56.0-dev.tar
-          pushd rust-src-1.56.0-dev
-          cp -ErrorAction SilentlyContinue -Recurse .\rust-src\lib\* ..\esp\lib\
-          popd
-          7z a esp.zip esp/
-      - name: Upload Release Asset
-        working-directory: D:/rust/build/dist
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.get_release.outputs.upload_url }}
-          asset_path: ${{ matrix.ASSET_PATH }}
-          asset_name: ${{ matrix.ASSET_NAME }}
-          asset_content_type: ${{ matrix.ASSET_CONTENT_TYPE }}
 
+        - os: windows-latest
+          target_name: x86_64-pc-windows-msvc
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/tools/setup-python
+      - uses: ./rust-build/.github/actions/tools/setup-ninja
+      - uses: ./rust-build/.github/actions/util/checkout-esp-rust
+      - uses: ./rust-build/.github/actions/util/symlink-working-dir
+      - uses: ./rust-build/.github/actions/build/build-rustc
+      - uses: ./rust-build/.github/actions/build/build-rust-std
+
+
+  build-tools:
+    # Build the tools - cargo / rustfmt
+    name: Build (idf) rust tools for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+        include:
+
+        - os: windows-latest
+          target_name: x86_64-pc-windows-msvc
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/tools/setup-python
+      - uses: ./rust-build/.github/actions/tools/setup-ninja
+      - uses: ./rust-build/.github/actions/util/checkout-esp-rust
+      - uses: ./rust-build/.github/actions/util/symlink-working-dir
+      - uses: ./rust-build/.github/actions/build/build-tools
+
+
+  build-src:
+    name: Build (idf) rust src for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+        include:
+
+        - os: windows-latest
+          target_name: x86_64-pc-windows-msvc
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/tools/setup-python
+      - uses: ./rust-build/.github/actions/tools/setup-ninja
+      - uses: ./rust-build/.github/actions/util/checkout-esp-rust
+      - uses: ./rust-build/.github/actions/util/symlink-working-dir
+      # Build the src - This is only bundled in with the windows build
+      - uses: ./rust-build/.github/actions/build/build-src
+        if: startsWith(matrix.os, 'windows')
+
+  upload-archive:
+    # Uploads a merged archive
+    name: Upload (idf) rust release for ${{ matrix.os }}
+    needs: [build-rustc, build-tools, build-src]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+        include:
+
+        - os: windows-latest
+          target_name: x86_64-pc-windows-msvc
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/util/create-archive
+      - uses: ./rust-build/.github/actions/util/upload

--- a/.github/workflows/build-rust-x86_64-unknown-linux-gnu-dispatch.yaml
+++ b/.github/workflows/build-rust-x86_64-unknown-linux-gnu-dispatch.yaml
@@ -1,93 +1,102 @@
-name: build-rust-ubuntu-dispatch
+name: Build ubuntu-latest x86_64
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      rust_build_branch:
+        description: 'Branch of rust-build to use'
+        required: true
+        default: 'main'
+      release_ver:
+        description: 'Release Version for generation'
+        required: true
+        default: '1.56.0.1'
+      rust_ver:
+        description: 'Version of esp rust to use'
+        required: true
+        default: '1.56.0'
 
+# We Break this down into individual jobs to avoid disk space issues
 jobs:
-  get_release:
-    # https://github.com/octokit/request-action
-    name: Get release
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.get_upload_url.outputs.url }}
-    steps:
-    - uses: octokit/request-action@v2.x
-      id: get_latest_release
-      with:
-        route: GET /repos/{owner}/{repo}/releases/latest
-        owner: esp-rs
-        repo: rust-build
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: get upload url
-      id: get_upload_url
-      run: |
-        url=$(echo "$response" | jq -r '.upload_url')
-        echo "::set-output name=url::$url"
-      env:
-        response:  ${{ steps.get_latest_release.outputs.data }}
 
-  build-idf-rust:
-    name: Build IDF Rust for ${{ matrix.os }}
-    # needs: create_release
-    needs: get_release
+  build-rustc:
+    # Build the compiler / std library
+    name: Build (idf) rustc/std for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         include:
-        - os: ubuntu-18.04
-          ARCH: ''
-          TARGET: linux-x64
-          ASSET_PATH: 'build/dist/rust-1.56.0-dev-x86_64-unknown-linux-gnu.tar.xz'
-          ASSET_NAME: 'rust-1.56.0.1-dev-x86_64-unknown-linux-gnu.tar.xz'
-          ASSET_CONTENT_TYPE: 'application/x-tar'
-          LLVM_ROOT_OPTION: ''
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          repository: esp-rs/rust
-          ref: esp-1.56.0
-          submodules: true
-      - name: Set up Python
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - name: Setup Ninja
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: seanmiddleditch/gha-setup-ninja@master
-      - name: Free up 24GB of disk space
-        run: sudo rm -rf /usr/share/dotnet
-      - name: Prepare build
-        run: python3 src/bootstrap/configure.py ${{ matrix.LLVM_ROOT_OPTION }} --experimental-targets=Xtensa --enable-extended --tools=rustfmt --dist-compression-formats='xz'
-      - name: Build with x.py - only components
-        if: ${{ matrix.os == 'windows-self-hosted' }}
-        run: |
-          python3 x.py build compiler/rustc src/tools/rustfmt library/std --stage 2
-          python3 x.py dist src --stage 2
-      - name: Build with x.py - dist packages
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' }}
-        run: python3 x.py dist --stage 2 --exclude src/doc
-        continue-on-error: true
-        # Excluding src/doc breaks build of 1.55
-        #run: python3 x.py dist --stage 2 --exclude src/doc
-      - name: Build with x.py - dist packages - continue on error - problem with Long path on Windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        continue-on-error: true
-        run: python3 x.py dist --stage 2
-      - name: Build with x.py - dist packages - with cached LLVM
-        if: ${{ matrix.os == 'macos-m1-self-hosted' }}
-        run: python3 x.py dist --stage 2 --exclude src/doc --llvm-skip-rebuild TRUE
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.get_release.outputs.upload_url }}
-          asset_path: ${{ matrix.ASSET_PATH }}
-          asset_name: ${{ matrix.ASSET_NAME }}
-          asset_content_type: ${{ matrix.ASSET_CONTENT_TYPE }}
 
+        - os: ubuntu-latest
+          target_name: x86_64-unknown-linux-gnu
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/tools/setup-python
+      - uses: ./rust-build/.github/actions/tools/setup-ninja
+      - uses: ./rust-build/.github/actions/util/checkout-esp-rust
+      - uses: ./rust-build/.github/actions/util/symlink-working-dir
+      - uses: ./rust-build/.github/actions/build/build-rustc
+      - uses: ./rust-build/.github/actions/build/build-rust-std
+
+
+  build-tools:
+    # Build the tools - cargo / rustfmt
+    name: Build (idf) rust tools for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        include:
+
+        - os: ubuntu-latest
+          target_name: x86_64-unknown-linux-gnu
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/tools/setup-python
+      - uses: ./rust-build/.github/actions/tools/setup-ninja
+      - uses: ./rust-build/.github/actions/util/checkout-esp-rust
+      - uses: ./rust-build/.github/actions/util/symlink-working-dir
+      - uses: ./rust-build/.github/actions/build/build-tools
+
+
+  upload-archive:
+    # Uploads a merged archive
+    name: Upload (idf) rust release for ${{ matrix.os }}
+    needs: [build-rustc, build-tools]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        include:
+
+        - os: ubuntu-latest
+          target_name: x86_64-unknown-linux-gnu
+          llvm_root_option: ''
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "rust-build"
+          ref: ${{ github.event.inputs.rust_build_branch }}
+      - uses: ./rust-build/.github/actions/util/setup-envs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./rust-build/.github/actions/util/create-archive
+      - uses: ./rust-build/.github/actions/util/upload

--- a/.github/workflows/test-rust-x86_64-apple-darwin-dispatch.yaml
+++ b/.github/workflows/test-rust-x86_64-apple-darwin-dispatch.yaml
@@ -19,27 +19,13 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        include:
-        - os: macos-latest
-          ARCH: ''
-          TARGET: macos-x64
-          ASSET_PATH: 'build/dist/rust-1.56.0.1-x86_64-apple-darwin.tar.xz'
-          ASSET_NAME: 'rust-1.56.0.1-x86_64-apple-darwin.tar.xz'
-          ASSET_CONTENT_TYPE: 'application/x-tar'
-          LLVM_ROOT_OPTION: ''
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.rust_build_branch }}
-      - name: Set up Python
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - name: Setup Ninja
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: seanmiddleditch/gha-setup-ninja@master
+      - uses: ./.github/actions/tools/setup-python
+      - uses: ./.github/actions/tools/setup-ninja
       - name: Test Rust toolchain by compiling STD demo
         run: ./test-rust-toolchain.sh --toolchain-version ${{ github.event.inputs.toolchain_version }}
-

--- a/.github/workflows/test-rust-x86_64-pc-windows-msvc-dispatch.yaml
+++ b/.github/workflows/test-rust-x86_64-pc-windows-msvc-dispatch.yaml
@@ -7,6 +7,10 @@ on:
         description: 'Branch with test scripts'
         required: true
         default: 'main'
+      toolchain_version:
+        description: 'Version of Rust IDF toolchain'
+        required: true
+        default: '1.56.0.1'
 
 jobs:
   build-idf-rust-examples:
@@ -15,27 +19,21 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        include:
-        - os: windows-latest
-          ARCH: ''
-          TARGET: win-x64
-          ASSET_PATH: 'build/dist/esp.zip'
-          ASSET_NAME: 'rust-1.56.0-dev-x86_64-pc-windows-msvc.zip'
-          ASSET_CONTENT_TYPE: 'application/zip'
-          LLVM_ROOT_OPTION: ''
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.rust_build_branch }}
-      - name: Set up Python
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - name: Setup Ninja
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: seanmiddleditch/gha-setup-ninja@master
-      - name: Test Rust
+      - uses: ./.github/actions/tools/setup-python
+      - uses: ./.github/actions/tools/setup-ninja
+
+      # Work around the windows path issue
+      - name: Symlink the working dir
         shell: pwsh
-        run: .\Test-RustToolchain.ps1
+        run: New-Item -Path D:/build -ItemType SymbolicLink -Value ${{ github.workspace }}
+
+      - name: Test Rust toolchain by compiling STD demo
+        working-directory: D:/build
+        shell: pwsh
+        run: .\Test-RustToolchain.ps1 -ToolchainVersion ${{ github.event.inputs.toolchain_version }}

--- a/.github/workflows/test-rust-x86_64-unknown-linux-gnu-dispatch.yaml
+++ b/.github/workflows/test-rust-x86_64-unknown-linux-gnu-dispatch.yaml
@@ -1,4 +1,4 @@
-name: Test Linux x86_64 - build of Rust examples
+name: Test Linux x86_64 - build of Rust examples 
 
 on:
   workflow_dispatch:
@@ -18,28 +18,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
-        include:
-        - os: ubuntu-18.04
-          ARCH: ''
-          TARGET: linux-x64
-          ASSET_PATH: 'build/dist/rust-1.56.1-x86_64-unknown-linux-gnu.tar.xz'
-          ASSET_NAME: 'rust-1.56.0.1-x86_64-unknown-linux-gnu.tar.xz'
-          ASSET_CONTENT_TYPE: 'application/x-tar'
-          LLVM_ROOT_OPTION: ''
+        os: [ubuntu-latest]
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.rust_build_branch }}
-      - name: Set up Python
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - name: Setup Ninja
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04' || matrix.os == 'windows-latest' }}
-        uses: seanmiddleditch/gha-setup-ninja@master
+      - uses: ./.github/actions/tools/setup-libudev
+      - uses: ./.github/actions/tools/setup-python
+      - uses: ./.github/actions/tools/setup-ninja
       - name: Test Rust toolchain by compiling STD demo
         run: ./test-rust-toolchain.sh --toolchain-version ${{ github.event.inputs.toolchain_version }}
-


### PR DESCRIPTION
Hi,
I've recently done a bit of a re-write of the github workflow scripts
From what I can gather I think they might be currently setup for self-hosted runners

This is the first time I've worked on github workflow so I don't expect this to go through as is, given it's size
more just some suggestions / ideas to get this running on github's native runners
Since I'd imagine a lot will depend on personal preference
Also I'm guessing the main branch is the one to push to

I've managed to add a few fixes / break things down into chunks here and there
So some of this may be of use.

## Results

So far the results of the builds I've done on the fork are viewable here

  * https://github.com/Hecatron-Forks/rust-build/releases/tag/v1.56.0.1
  * https://github.com/Hecatron-Forks/rust-build/actions


## Composite Actions

A lot of the main build is broken down into composite actions to try and simplify things
These are located under .github/actions/
So most of the build steps at the top level are just a single line of text.


## Files Changed

The following files have been updated
The windows test one doesn't currently work, but that just fails in the same way as the current one does.

  * build-rust-x86_64-pc-windows-msvc-dispatch.yaml
  * build-rust-x86_64-unknown-linux-gnu-dispatch.yaml
  * build-rust-x86_64-apple-darwin-dispatch.yaml
  * test-rust-x86_64-pc-windows-msvc-dispatch.yaml
  * test-rust-x86_64-unknown-linux-gnu-dispatch.yaml
  * test-rust-x86_64-apple-darwin-dispatch.yaml



I've not made any changes to the following or the publish ones (for docker)
as I think these relate to a self hosted builder.

  * build-rust-aarch64-apple-darwin-dispatch.yaml
  * test-rust-aarch64-apple-darwin-dispatch.yaml
  * test-rust-x86_64-pc-windows-msvc-self-hosted-dispatch.yaml

## Windows Test

For the windows test one, this is currently failing in the same way the original is
as far as I can tell xtensa-esp32-elf-gcc.exe I think is trying to find / launch a different executable
but isn't saying which, so finding a way to run it with -v may reveal more

It does work however as I've used it on my own machine under windows to build a basic blinky project.

## build-rust-dispatch.yaml

You could update this file by copying / pasting one of the above.
I think the idea behind this one is to build for all platforms on a matrix.
I didn't update it since there's self hosted builds involved.


## OS checks

The operating system checks are typically done via lines like
```
if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
```
So in theory the actions should also work on the self hosted builders


## Build src workflow

I noticed that with the windows builds, rust-src is incorperated into the final zip
but with ubuntu / macos these use a seperate .tar.xz file during the tests
So I've setup a workflow for generating that seperate file

However one thing I did spot is that the built source file will be different based on if macos or ubuntu is used as the runner.
I think the current repo is using macos-latest based on diff
so perhaps there should be seperate files for ubuntu / macos, or perhaps rust-src should be bundled into the main per os archive for unix builds


## Multiple Jobs

Currently the build is being split into multiple jobs to get around issues with disk space
Since you only get around 10 - 14Gb with github's native runners.
This definitley impacts the Windows builds, I suspect it would also impact the unix ones as well.

With a self hosted runner you could probably merge that into one job using the composite actions

Also the build is just building those specific things needed instead of trying to build everything.
This seems to avoid the issue of the build erroring out part way through if you try to just do everything all at once.

## Sequence of steps

Current sequence of steps broadly speaking is

  * Checkout rust-build to a rust-build subdir to access the .github/actions scripts
  * Setup a bunch of enviroment variables
  * Setup python
  * Setup ninja
  * Checkout esp rust to a rust subdir
  * For windows symlink (using mklink) the checked out rust dir to D:/rust to avoid path too long issues
  * Build / dist rustc / rust-std lib as part of one job
  * Build / dist the tools rustfmt / cargo as part of another job
  * Dist the src as another job (windows only)
  * Merge all the archives into one
  * Upload to the release tag / create a release if one doesn't already exist for the tag


## Windows Working Directory

The working directory is set to D:/rust for the windows builds
this is done via a symbolic link using mklink after checkout
This resolves path length issues


## Tools Included

Cargo was included in just the windows build to fix this issue with rust-analayser under vscode and cargo make
https://github.com/esp-rs/rust-build/issues/17
Also there's rustfmt in there as well


## Things to check

  * build-rust-on-tag.yaml
    I think this might be redundant  / perhaps can be removed
    since the upload now uses softprops/action-gh-release@v1
    which will automatically turn a tag into a release while uploading files

  * Instead of building esp llvm
    One thing I've not tried is using the binary release of https://github.com/espressif/llvm-project
    Since that would save a chunk of disk space
    then run the build with --llvm-skip-rebuild TRUE

  * test-rust-x86_64-pc-windows-msvc-dispatch.yaml
    this currently fails, but fails in the same way as the existing script

  * There's no rust-docs bundled in the release
    This is in the original but I wasn't sure if it was just a biproduct of the way the build was working
    It's not currently in this build setup, but should be easy to add in if needed.
