### PR TITLE
Fully qualify podman example

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Alternatively you might build the project in the container where image already c
 Podman example with mapping multiple /dev/ttyUSB from host computer to the container:
 
 ```
-podman run --device /dev/ttyUSB0 --device /dev/ttyUSB1 -it espressif/idf-rust-examples
+podman run --device /dev/ttyUSB0 --device /dev/ttyUSB1 -it docker.io/espressif/idf-rust-examples
 ```
 
 Docker (does not support flashing from container):


### PR DESCRIPTION
Podman is more agnostic than Docker in regard to the default container registry. As such, we should specify it to be docker.io explicitly.