### PR TITLE
Add info to README about container images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,11 @@ rustup target add riscv32i-unknown-none-elf
 
 ### Rust with Podman or Docker
 
-Alternatively you might build the project in the container where image already contains pre-installed Rust and ESP-IDF.
+Alternatively, you might build the project in the container where the image already contains pre-installed Rust and ESP-IDF.
+
+There are two different images published to Dockerhub: 
+- [idf-rust](https://hub.docker.com/r/espressif/idf-rust) - contains only the toolchain.
+- [idf-rust-examples](https://hub.docker.com/r/espressif/idf-rust-examples) - includes two examples: [rust-esp32-example](https://github.com/espressif/rust-esp32-example) and [rust-esp32-std-demo](https://github.com/ivmarkov/rust-esp32-std-demo).
 
 Podman example with mapping multiple /dev/ttyUSB from host computer to the container:
 
@@ -162,6 +166,6 @@ Docker (does not support flashing from container):
 docker run -it espressif/idf-rust-examples
 ```
 
-Then follow instructions displayed on the screen.
+If you are using the `idf-rust-examples` image, instructions will be displayed on the screen.
 
 


### PR DESCRIPTION
Hello,

I found the Docker/Podman section in the Readme a bit confusing. Here's an edit making it more apparent that there is a toolchain-only container available on Dockerhub.

BTW, the `rust-idf-examples` image hasn't been updated in a while (about a month). Not sure if that's intentional.

Thanks for your work!

Jens
