### PR TITLE
Update shell scripts' shebang to use env

### DIFF
--- a/install-rust-toolchain.sh
+++ b/install-rust-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Default values
 TOOLCHAIN_VERSION="1.59.0.0"

--- a/support/rust-build/aarch64-unknown-linux-gnu/build.sh
+++ b/support/rust-build/aarch64-unknown-linux-gnu/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/support/rust-build/rename-rust-release.sh
+++ b/support/rust-build/rename-rust-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for I in *1.59.0-dev*; do
      NEW_NAME=`echo $I | sed -e 's/1.59.0-dev/1.59.0.0/g'`

--- a/support/rust-build/x86_64-unknown-linux-gnu/build.sh
+++ b/support/rust-build/x86_64-unknown-linux-gnu/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test-rust-toolchain.sh
+++ b/test-rust-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Replace all occurrences of `#!/bin/bash` with `#!/usr/bin/env bash` in order to improve the [compatibility](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my).

Closes #39 