### PR TITLE
Fix argument parsing bug for --clear-cache option

### DIFF
--- a/install-rust-toolchain.sh
+++ b/install-rust-toolchain.sh
@@ -79,7 +79,8 @@ while [[ $# -gt 0 ]]; do
       ;;
     -x|--clear-cache)
       CLEAR_DOWNLOAD_CACHE="$2"
-      shift
+      shift # past argument
+      shift # past value
       ;;
     *)    # unknown option
       POSITIONAL+=("$1") # save it in an array for later


### PR DESCRIPTION
The --clear-cache option requires an argument: YES or NO.
If shift is called only once, then the value of --clear-cache
is parsed as an argument in its own right.

This leads to either YES or NO being stored and then restored
as a positional argument. It doesn't currently seem to be harmful
but it is inaccurate and could lead to bugs in the future.