### PR TITLE
Feature/add arguments

### DIFF
--- a/install-rust-toolchain.sh
+++ b/install-rust-toolchain.sh
@@ -154,11 +154,6 @@ function source_cargo() {
     fi
 }
 
-# function install_rust_toolchain() {
-#     rustup toolchain install $1 --profile minimal --component rustfmt
-# }
-
-
 function install_rust_xtensa_toolchain() {
     if [ -d "${TOOLCHAIN_DESTINATION_DIR}" ]; then
         echo "Previous installation of toolchain exist in: ${TOOLCHAIN_DESTINATION_DIR}"
@@ -259,8 +254,6 @@ if [ "${RUSTC_MINOR_VERSION}" -lt "${RUSTC_MINIMAL_MINOR_VERSION}" ]; then
     echo "calling rustup"
     install_rustup
 fi
-
-# rustup toolchain list | grep ${NIGHTLY_VERSION} || install_rust_toolchain ${NIGHTLY_VERSION}
 
 ARCH=`rustup show | grep "Default host" | sed -e 's/.* //'`
 LLVM_DIST_MIRROR="https://github.com/espressif/llvm-project/releases/download/${LLVM_VERSION}"


### PR DESCRIPTION
- Add `-n|--nightly-version` argument to choose nightly version for RiscV targets
- Add `-s|--esp-idf-version` argument to install esp-idf. It will install the passed esp-idf version for the targets specified in  `--build-target`
  - Add  `--minified-esp-idf` to clean some unnecessary folders of esp-idf
  - Merge esp-idf export file with the one generated for the xtensa rust toolchain
- `-b|--build-target` now takes a comma-separated list, using spaces was causing some issues
- Remove installing `stable` and `nightly` toolchains when installing the xtensa rust toolchain
- Install `xtensa-esp32-elf-gcc` when esp-idf is not being installed