### PR TITLE
add unzip to list of Ubuntu/Debian dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Instructions for ESP-C series based on RISC-V architecture are described in [RIS
   
     ```sh
     apt-get install -y git curl gcc ninja-build cmake libudev-dev \
-      python3 python3-pip libusb-1.0-0 libssl-dev pkg-config libtinfo5
+      python3 python3-pip libusb-1.0-0 libssl-dev pkg-config libtinfo5 \
+      unzip
     ```
 
 No prerequisites are needed for macOS


### PR DESCRIPTION
The Rust 1.61 version of install-rust-toolchain.sh calls unzip, which isn't installed on Ubuntu/Debian by default (at least not on our ubuntu:20.04-based Docker container).

This branch adds the utility to the list of dependencies in README.md, so users know to install it before running install-rust-toolchain.sh on Ubuntu/Debian.