### PR TITLE
Fix the RISC-V target in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Following instructions are specific for ESP32-C based on RISC-V architecture.
 Install the RISC-V target for Rust:
 
 ```sh
-rustup target add riscv32i-unknown-none-elf
+rustup target add riscv32imc-unknown-none-elf
 ```
 
 ## Building projects

--- a/install-rust-toolchain.sh
+++ b/install-rust-toolchain.sh
@@ -272,7 +272,7 @@ function install_rust_riscv_toolchain() {
     --default-toolchain ${NIGHTLY_VERSION} \
     --component rust-src \
     --profile minimal \
-    --target riscv32i-unknown-none-elf -y
+    --target riscv32imc-unknown-none-elf -y
 }
 
 function install_crate_from_zip() {


### PR DESCRIPTION
Just noticed this one. While using only the `i` extension will likely be fine for simple demos, it's best to include all supported extensions. Hardware-accelerated multiplication/division (`m`) and compressed instructions (`c`) are both pretty useful.