### PR TITLE
Update crates order

### DIFF
--- a/install-rust-toolchain.sh
+++ b/install-rust-toolchain.sh
@@ -323,14 +323,15 @@ function install_crate_from_tar_gz() {
 }
 
 function install_extra_crates() {
-    if [[ "${EXTRA_CRATES}" =~ "espflash" ]] && [ -n "${ESPFLASH_URL}" ] && [ -n "${ESPFLASH_BIN}" ]; then
-        install_crate_from_zip "${ESPFLASH_URL}" "${ESPFLASH_BIN}"
-        EXTRA_CRATES="${EXTRA_CRATES/espflash/}"
-    fi
 
     if [[ "${EXTRA_CRATES}" =~ "cargo-espflash" ]] && [ -n "${CARGO_ESPFLASH_URL}" ] && [ -n "${CARGO_ESPFLASH_BIN}" ]; then
         install_crate_from_zip "${CARGO_ESPFLASH_URL}" "${CARGO_ESPFLASH_BIN}"
         EXTRA_CRATES="${EXTRA_CRATES/cargo-espflash/}"
+    fi
+
+    if [[ "${EXTRA_CRATES}" =~ "espflash" ]] && [ -n "${ESPFLASH_URL}" ] && [ -n "${ESPFLASH_BIN}" ]; then
+        install_crate_from_zip "${ESPFLASH_URL}" "${ESPFLASH_BIN}"
+        EXTRA_CRATES="${EXTRA_CRATES/espflash/}"
     fi
 
     if [[ "${EXTRA_CRATES}" =~ "ldproxy" ]]  && [ -n "${LDPROXY_URL}" ] && [ -n "${LDPROXY_BIN}" ]; then


### PR DESCRIPTION
When installing `cargo-espflash` there was an issue as it was installing `espflash` binary and then trying to: `cargo install cargo-`, changing the order of the checks solves that issue.