### PR TITLE
Add some CI to build template projects when changing the installer

### DIFF
--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -1,0 +1,94 @@
+name: Test installer by building template projects
+
+on:
+  push:
+    paths:
+      - "install-rust-toolchain.sh"
+  pull_request:
+    paths:
+      - "install-rust-toolchain.sh"
+  workflow_dispatch:
+
+jobs:
+  esp-idf-v4-4:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ['esp32', 'esp32s3', 'esp32s3', 'esp32c3']
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.rust-build-branch }}
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install ninja-build
+      - name: Install toolchain
+        run: |
+          bash install-rust-toolchain.sh \
+          --extra-crates "ldproxy cargo-generate" \
+          --build-target "${{ matrix.board }}" \
+          --esp-idf-version "release/v4.4" \
+          --minified-esp-idf "YES" \
+          --export-file  "${HOME}/export-esp.sh"
+      - name: Build template project
+        run: |
+          source ${HOME}/export-esp.sh
+          cargo generate --git https://github.com/esp-rs/esp-idf-template --branch fix/remove-toolchain-question cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d std=true -d espidfver=v4.4 -d devcontainer=false
+          cd test-${{ matrix.board }}
+          cargo build
+  esp-idf-master:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ['esp32', 'esp32s3', 'esp32s3', 'esp32c3']
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.rust-build-branch }}
+      - name: Install toolchain
+        run: |
+          bash install-rust-toolchain.sh \
+          --extra-crates "ldproxy cargo-generate" \
+          --build-target "${{ matrix.board }}" \
+          --esp-idf-version "master" \
+          --minified-esp-idf "YES" \
+          --export-file  "${HOME}/export-esp.sh"
+      - name: Build template project
+        run: |
+          source ${HOME}/export-esp.sh
+          cargo generate --git https://github.com/esp-rs/esp-idf-template --branch fix/remove-toolchain-question cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d std=true -d espidfver=mainline -d devcontainer=false
+          cd test-${{ matrix.board }}
+          cargo build
+  bare-metal:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ['esp32', 'esp32s3', 'esp32s3', 'esp32c3']
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.rust-build-branch }}
+      - name: Install toolchain
+        run: |
+          bash install-rust-toolchain.sh \
+          --extra-crates "ldproxy cargo-generate" \
+          --build-target "${{ matrix.board }}" \
+          --export-file  "${HOME}/export-esp.sh"
+      - name: Build template project
+        run: |
+          source ${HOME}/export-esp.sh
+          cargo generate --git https://github.com/esp-rs/esp-template --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=false
+          cd test-${{ matrix.board }}
+          cargo build
+
+

--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -5,7 +5,6 @@ on:
     paths:
       - "install-rust-toolchain.sh"
   pull_request:
-    branches: [ main ]
     paths:
       - "install-rust-toolchain.sh"
   workflow_dispatch:

--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - "install-rust-toolchain.sh"
   pull_request:
+    branches: [ main ]
     paths:
       - "install-rust-toolchain.sh"
   workflow_dispatch:


### PR DESCRIPTION
As I am tired of breaking the installer, I figured out that this CI would be helpful, it compiles the `esp-idf-template` project for all boards and the 2 esp-idf versions: `master` and `release/v4.4` (`master` is failing due to https://github.com/esp-rs/esp-idf-sys/issues/99) and also builds `esp-template` for all boards.

The installer is way more complex than what we are testing here, but it's a start and later on, we could add more test cases.