### PR TITLE
Exports were not properly working for `esp32c3`

### DIFF
--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -52,6 +52,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.rust-build-branch }}
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install ninja-build
       - name: Install toolchain
         run: |
           bash install-rust-toolchain.sh \

--- a/idf-rust.Containerfile
+++ b/idf-rust.Containerfile
@@ -9,7 +9,7 @@ ARG CONTAINER_USER=esp
 ARG CONTAINER_GROUP=esp
 ARG NIGHTLY_TOOLCHAIN_VERSION=nightly
 ARG XTENSA_TOOLCHAIN_VERSION=1.62.0.0
-ARG ESP_IDF_VERSION=release/v4.4
+ARG ESP_IDF_VERSION=""
 ARG ESP_BOARD=esp32,esp32s2,esp32s3
 ARG INSTALL_RUST_TOOLCHAIN=install-rust-toolchain.sh
 # Install dependencies
@@ -29,7 +29,6 @@ ADD --chown=${CONTAINER_USER}:${CONTAINER_GROUP} \
 RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     && ./${INSTALL_RUST_TOOLCHAIN} \
     --extra-crates "ldproxy cargo-espflash cargo-generate" \
-    --clear-cache "YES" \
     --build-target "${ESP_BOARD}" \
     --nightly-version "${NIGHTLY_TOOLCHAIN_VERSION}" \
     --esp-idf-version "${ESP_IDF_VERSION}" \

--- a/install-rust-toolchain.sh
+++ b/install-rust-toolchain.sh
@@ -603,21 +603,25 @@ elif grep -q "bash" <<< "$SHELL"; then
     PROFILE_NAME=~/.bashrc
 fi
 echo "Add following command to $PROFILE_NAME"
-if [ -z "${ESP_IDF_VERSION}" ]; then
-    echo export PATH=\"${IDF_TOOL_GCC_PATH}:\$PATH\"
-    echo export LIBCLANG_PATH=\"${IDF_TOOL_XTENSA_ELF_CLANG}/lib/\"
-else
+if [ ${IS_XTENSA_INSTALLED} -eq 1 ]; then
+    echo export LIBCLANG_PATH=\"${IDF_TOOL_XTENSA_ELF_CLANG}/lib/\" >>"${EXPORT_FILE}"
+fi
+if [ -n "${ESP_IDF_VERSION}" ]; then
     echo "export IDF_TOOLS_PATH=${IDF_TOOLS_PATH}"
     echo "source ${IDF_PATH}/export.sh"
+else
+    echo export PATH=\"${IDF_TOOL_GCC_PATH}:\$PATH\"
 fi
 
 # Store export instructions in the file
 if [[ ! -z "${EXPORT_FILE}" ]]; then
-    if [ -z "${ESP_IDF_VERSION}" ]; then
-        echo export PATH=\"${IDF_TOOL_GCC_PATH}:\$PATH\" >"${EXPORT_FILE}"
+    if [ ${IS_XTENSA_INSTALLED} -eq 1 ]; then
         echo export LIBCLANG_PATH=\"${IDF_TOOL_XTENSA_ELF_CLANG}/lib/\" >>"${EXPORT_FILE}"
-    else
+    fi
+    if [ -n "${ESP_IDF_VERSION}" ]; then
         echo "export IDF_TOOLS_PATH=${IDF_TOOLS_PATH}" >>"${EXPORT_FILE}"
         echo "source ${IDF_PATH}/export.sh /dev/null 2>&1" >>"${EXPORT_FILE}"
+    else
+        echo export PATH=\"${IDF_TOOL_GCC_PATH}:\$PATH\" >"${EXPORT_FILE}"
     fi
 fi


### PR DESCRIPTION
Fixed environment variables as they were not working for `esp32c3`. I've run [this CI](https://github.com/esp-rs/rust-build/pull/110) [on my fork](https://github.com/SergioGasquez/rust-build/actions/runs/2678460138) and all the targets seem to be working in esp-idf release v4.4 and for bare-metal (esp-idf master is failing for all of them as expected due to https://github.com/esp-rs/esp-idf-sys/issues/99). I've also updated Containerfile default values

