### PR TITLE
Add more test cases

### DIFF
--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        arguments: ["", "--toolchain-version ${{ xtensa-toolchain-version }} --export-file export-esp-rust.sh", "--build-target all"]
+        arguments: ["", "--toolchain-version $xtensa-toolchain-version --export-file export-esp-rust.sh", "--build-target all"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -107,6 +107,7 @@ jobs:
           cd test-${{ matrix.board }}
           cargo build
   crate-check:
+    if: github.event_name != 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -124,6 +125,7 @@ jobs:
       - name: Install toolchain
         run: ./install-rust-toolchain.sh --extra-crates "${{ matrix.extra-crates }}"
   minified-llvm:
+    if: github.event_name != 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -143,6 +145,7 @@ jobs:
           ./install-rust-toolchain.sh \
           --minified-llvm "${{ matrix.minified-llvm }}"
   installation-modes:
+    if: github.event_name != 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -164,6 +167,7 @@ jobs:
         run: |
           ./install-rust-toolchain.sh --installation-mode "uninstall"
   test-arguments:
+    if: github.event_name != 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -1,5 +1,8 @@
 name: Test installer by building template projects
 
+env:
+  xtensa-toolchain-version: '1.62.1.0'
+
 on:
   push:
     paths:
@@ -165,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        arguments: ["", "--toolchain-version 1.62.1.0 --export-file export-esp-rust.sh", "--build-target all"]
+        arguments: ["", "--toolchain-version ${{ env.xtensa-toolchain-version }} --export-file export-esp-rust.sh", "--build-target all"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -108,6 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        extra-crates: ["", "ldproxy", "espflash cargo-espflash ldproxy cargo-generate wokwi-server web-flash"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -118,9 +119,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.rust-build-branch }}
       - name: Install toolchain
-        run: |
-          ./install-rust-toolchain.sh \
-          --extra-crates "espflash cargo-espflash ldproxy cargo-generate wokwi-server web-flash"
+        run: ./install-rust-toolchain.sh --extra-crates "${{ matrix.extra-crates }}"
   minified-llvm:
     strategy:
       fail-fast: false

--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        arguments: ["", "--toolchain-version ${{ env.xtensa-toolchain-version }} --export-file export-esp-rust.sh", "--build-target all"]
+        arguments: ["", "--toolchain-version ${{ xtensa-toolchain-version }} --export-file export-esp-rust.sh", "--build-target all"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -107,7 +107,7 @@ jobs:
           cd test-${{ matrix.board }}
           cargo build
   crate-check:
-    if: github.event_name != 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -125,7 +125,7 @@ jobs:
       - name: Install toolchain
         run: ./install-rust-toolchain.sh --extra-crates "${{ matrix.extra-crates }}"
   minified-llvm:
-    if: github.event_name != 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +145,7 @@ jobs:
           ./install-rust-toolchain.sh \
           --minified-llvm "${{ matrix.minified-llvm }}"
   installation-modes:
-    if: github.event_name != 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -167,7 +167,7 @@ jobs:
         run: |
           ./install-rust-toolchain.sh --installation-mode "uninstall"
   test-arguments:
-    if: github.event_name != 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/installer-check.yaml
+++ b/.github/workflows/installer-check.yaml
@@ -140,3 +140,40 @@ jobs:
         run: |
           ./install-rust-toolchain.sh \
           --minified-llvm "${{ matrix.minified-llvm }}"
+  installation-modes:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        run: |
+          ./install-rust-toolchain.sh --installation-mode "install"
+      - name: Reinstall toolchain
+        run: |
+          ./install-rust-toolchain.sh --installation-mode "reinstall"
+      - name: Uninstall toolchain
+        run: |
+          ./install-rust-toolchain.sh --installation-mode "uninstall"
+  test-arguments:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        arguments: ["", "--toolchain-version 1.62.1.0 --export-file export-esp-rust.sh", "--build-target all"]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        run: |
+          ./install-rust-toolchain.sh "${{ matrix.arguments }}"

--- a/README.md
+++ b/README.md
@@ -94,13 +94,14 @@ source export-esp-rust.sh
 - `-e|--extra-crates`: Extra crates to install. Defaults to: `ldproxy cargo-espflash`
 - `-f|--export-file`: Destination of the export file generated.
 - `-i|--installation-mode`: Installation mode: [`install, reinstall, uninstall`]. Defaults to: `install`
+- `-k|--minified-llvm`: Use minified LLVM. Possible values: [`YES, NO`]. Defaults to: `YES`
 - `-l|--llvm-version`: LLVM version.
-- `-m|--minified-esp-idf`: [Only applies if using `-s|--esp-idf-version`]. Deletes some idf folders to save space. Possible values [`YES, NO`]
+- `-m|--minified-esp-idf`: [Only applies if using `-s|--esp-idf-version`]. Deletes some idf folders to save space. Possible values [`YES, NO`]. Defaults to: `NO`
 - `-n|--nightly-version`: Nightly Rust toolchain version. Defaults to: `nightly`
 - `-r|--rustup-home`: Path to .rustup. Defaults to: `~/.rustup`
 - `-s|--esp-idf-version`: [ESP-IDF branch](https://github.com/espressif/esp-idf/branches) to install. When empty, no esp-idf is installed. Default: `""`
 - `-t|--toolchain-version`: Xtensa Rust toolchain version
-- `-x|--clear-cache`: Removes cached distribution files. Possible values: [`YES, NO`]
+- `-x|--clear-cache`: Removes cached distribution files. Possible values: [`YES, NO`]. Defaults to: `YES`
 
 ### Windows x86_64 GNU
 

--- a/install-rust-toolchain.sh
+++ b/install-rust-toolchain.sh
@@ -535,10 +535,10 @@ elif [[ ${ARCH} == "x86_64-unknown-linux-gnu" ]]; then
     ESPFLASH_BIN="${CARGO_HOME}/bin/espflash"
     LDPROXY_URL="https://github.com/esp-rs/embuild/releases/latest/download/ldproxy-${ARCH}.zip"
     LDPROXY_BIN="${CARGO_HOME}/bin/ldproxy"
-    if [[ "${EXTRA_CRATES}" =~ "cargo-generate" ]]; then
-        GENERATE_URL="https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-${GENERATE_VERSION}-${ARCH}.tar.gz"
-    fi
-    GENERATE_BIN="${CARGO_HOME}/bin/cargo-generate"
+    # if [[ "${EXTRA_CRATES}" =~ "cargo-generate" ]]; then
+    #     GENERATE_URL="https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-${GENERATE_VERSION}-${ARCH}.tar.gz"
+    # fi
+    # GENERATE_BIN="${CARGO_HOME}/bin/cargo-generate"
     WOKWI_SERVER_URL="https://github.com/MabezDev/wokwi-server/releases/latest/download/wokwi-server-${ARCH}.zip"
     WOKWI_SERVER_BIN="${CARGO_HOME}/bin/wokwi-server"
     WEB_FLASH_URL="https://github.com/bjoernQ/esp-web-flash-server/releases/latest/download/web-flash-${ARCH}.zip"
@@ -547,10 +547,10 @@ elif [[ ${ARCH} == "aarch64-unknown-linux-gnu" ]]; then
     GCC_ARCH="linux-arm64"
     MINIFIED_LLVM="YES"
     SYSTEM_PACKAGES=""
-    if [[ "${EXTRA_CRATES}" =~ "cargo-generate" ]]; then
-        GENERATE_URL="https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-${GENERATE_VERSION}-${ARCH}.tar.gz"
-    fi
-    GENERATE_BIN="${CARGO_HOME}/bin/cargo-generate"
+    # if [[ "${EXTRA_CRATES}" =~ "cargo-generate" ]]; then
+    #     GENERATE_URL="https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-${GENERATE_VERSION}-${ARCH}.tar.gz"
+    # fi
+    # GENERATE_BIN="${CARGO_HOME}/bin/cargo-generate"
     CARGO_ESPFLASH_URL="https://github.com/esp-rs/espflash/releases/latest/download/cargo-espflash-${ARCH}.zip"
     CARGO_ESPFLASH_BIN="${CARGO_HOME}/bin/cargo-espflash"
     ESPFLASH_URL="https://github.com/esp-rs/espflash/releases/latest/download/espflash-${ARCH}.zip"


### PR DESCRIPTION
Improve the CI that test the installer:
- Add a test that verifies the 3 installation modes
- Add a test that uses the installer with different arguments
- Update `crate-check` job to contain more test cases
- Update documentation with `1.62.1.0` argument changes
- Test cases are now split:
  - On PRs and pushes only tests that check that projects are building will be executed
  - When triggering the workflow manually, all the test cases will be executed