### PR TITLE
Build without linking to homebrew libs

### DIFF
--- a/.github/workflows/build-rust-aarch64-apple-darwin-self-hosted-dispatch.yaml
+++ b/.github/workflows/build-rust-aarch64-apple-darwin-self-hosted-dispatch.yaml
@@ -71,7 +71,7 @@ jobs:
           submodules: true
       - name: Prepare build
         run: |
-          arch -arm64 python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --set rust.jemalloc
+          arch -arm64 python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --set rust.jemalloc
       - name: Build with x.py - dist packages - with cached LLVM
         run: arch -arm64 python3 x.py dist --stage 2 || echo "silence pkg build error"
       - name: Upload Release Asset


### PR DESCRIPTION
The `openssl-sys` crate will either link against a Homebrew-provided
OpenSSL, or it will build OpenSSL itself.

Using the `cargo-native-static` build option will force `openssl-sys` to
build OpenSSL itself. This produces binaries that do not link against
any non-system-provided libraries. This is how official builds of
`rust-lang/rust` are performed. See
https://github.com/rust-lang/rust/blob/da5b546d2e563747b16a16dae83bacf49aa0bf3b/src/ci/run.sh#L54

Fixes: #29