### PR TITLE
Update install script to use the latest release 1.65.0.0

### DIFF
--- a/install-rust-toolchain.sh
+++ b/install-rust-toolchain.sh
@@ -4,7 +4,7 @@ set -eu
 #set -v
 
 # Default values
-TOOLCHAIN_VERSION="1.64.0.0"
+TOOLCHAIN_VERSION="1.65.0.0"
 RUSTUP_HOME="${RUSTUP_HOME:-${HOME}/.rustup}"
 CARGO_HOME="${CARGO_HOME:-${HOME}/.cargo}"
 TOOLCHAIN_DESTINATION_DIR="${RUSTUP_HOME}/toolchains/esp"


### PR DESCRIPTION
This is a quick fix as per the discussion in https://github.com/esp-rs/rust-build/issues/164