### PR TITLE
Change "7z e" to "7z x" to maintain directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Install MinGW x86_64 e.g., from releases https://github.com/niXman/mingw-builds-
 ```powershell
 choco install 7zip -y
 Invoke-WebRequest https://github.com/niXman/mingw-builds-binaries/releases/download/12.1.0-rt_v10-rev3/x86_64-12.1.0-release-posix-seh-rt_v10-rev3.7z -OutFile x86_64-12.1.0-release-posix-seh-rt_v10-rev3.7z
-7z e x86_64-12.1.0-release-posix-seh-rt_v10-rev3.7z
+7z x x86_64-12.1.0-release-posix-seh-rt_v10-rev3.7z
 $env:PATH+=";.....\x86_64-12.1.0-release-posix-seh-rt_v10-rev3\mingw64\bin"
 ```
 


### PR DESCRIPTION
`7z e` causes all the contained files to be extracted at the current level, ignoring directory structure.  We should instead use `7z x`.