### PR TITLE
Build rust-analyzer-proc-macro-srv

### DIFF
--- a/support/rust-build/aarch64-unknown-linux-gnu/build.sh
+++ b/support/rust-build/aarch64-unknown-linux-gnu/build.sh
@@ -4,5 +4,5 @@ set -e
 
 git clone --recursive --depth 1 --shallow-submodules https://github.com/esp-rs/rust.git
 cd rust
-python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${RELEASE_DESCRIPTION}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --enable-lld
+python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${RELEASE_DESCRIPTION}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --enable-lld
 python3 x.py dist --stage 2

--- a/support/rust-build/x86_64-pc-windows-gnu/build-rust-toolchain-msys2.sh
+++ b/support/rust-build/x86_64-pc-windows-gnu/build-rust-toolchain-msys2.sh
@@ -4,6 +4,6 @@ cd c:
 git clone --recursive --depth 1 --shallow-submodules https://github.com/esp-rs/rust.git r
 cd r
 
-python3 src/bootstrap/configure.py --experimental-targets=Xtensa --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --host 'x86_64-pc-windows-gnu' --enable-lld
+python3 src/bootstrap/configure.py --experimental-targets=Xtensa --enable-extended --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --host 'x86_64-pc-windows-gnu' --enable-lld
 
 python3 x.py dist --stage 2

--- a/support/rust-build/x86_64-unknown-linux-gnu/build.sh
+++ b/support/rust-build/x86_64-unknown-linux-gnu/build.sh
@@ -4,6 +4,6 @@ set -e
 
 git clone --recursive --depth 1 --shallow-submodules https://github.com/esp-rs/rust.git
 cd rust
-python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${RELEASE_DESCRIPTION}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --enable-lld
+python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${RELEASE_DESCRIPTION}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --enable-lld
 python3 x.py dist --stage 2
 


### PR DESCRIPTION
The proc-macro server needs to be built and distributed for rust-analyzer to be able to expand proc-macros.

Fixes esp-rs/espup#254.