### PR TITLE
Include `rust-analyzer-proc-macro-srv` for all targets

### DIFF
--- a/.github/actions/build/build-src/action.yaml
+++ b/.github/actions/build/build-src/action.yaml
@@ -10,7 +10,7 @@ runs:
       if: startsWith(matrix.os, 'windows')
       working-directory: ${{ env.work_dir }}
       shell: pwsh
-      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz'
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz'
 
     - name: Dist with x.py - Src - Windows
       if: startsWith(matrix.os, 'windows')
@@ -24,13 +24,13 @@ runs:
       if: startsWith(matrix.os, 'macos')
       working-directory: ${{ env.work_dir }}
       shell: bash
-      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --set rust.jemalloc
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --set rust.jemalloc
 
     - name: Prepare build - Unix
       if: startsWith(matrix.os, 'ubuntu')
       working-directory: ${{ env.work_dir }}
       shell: bash
-      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz'
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz'
 
     - name: Dist with x.py - Src - Unix
       if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')

--- a/.github/actions/build/build-tools/action.yaml
+++ b/.github/actions/build/build-tools/action.yaml
@@ -10,7 +10,7 @@ runs:
       if: startsWith(matrix.os, 'windows')
       working-directory: ${{ env.work_dir }}
       shell: pwsh
-      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz'
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz'
 
     #- name: Build with x.py - Tools
     #  if: startsWith(matrix.os, 'windows')
@@ -33,13 +33,13 @@ runs:
       if: startsWith(matrix.os, 'macos')
       working-directory: ${{ env.work_dir }}
       shell: bash
-      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --set rust.jemalloc
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --set rust.jemalloc
 
     - name: Prepare build
       if: startsWith(matrix.os, 'ubuntu')
       working-directory: ${{ env.work_dir }}
       shell: bash
-      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz'
+      run: python3 src/bootstrap/configure.py ${{ matrix.llvm_root_option }} --experimental-targets=Xtensa --release-channel=nightly --enable-extended --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz'
 
     - name: Build with x.py - Tools
       if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/build-rust-aarch64-apple-darwin-self-hosted-dispatch.yaml
+++ b/.github/workflows/build-rust-aarch64-apple-darwin-self-hosted-dispatch.yaml
@@ -74,7 +74,7 @@ jobs:
           submodules: true
       - name: Prepare build
         run: |
-          arch -arm64 python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${{ github.event.inputs.release_version }}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --set rust.jemalloc --enable-lld
+          arch -arm64 python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${{ github.event.inputs.release_version }}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --set rust.jemalloc --enable-lld
       - name: Build with x.py - dist packages - with cached LLVM
         run: arch -arm64 python3 x.py dist --stage 2 || echo "silence pkg build error"
       - name: Upload Release Asset

--- a/.github/workflows/build-rust-x86_64-apple-darwin-self-hosted-dispatch.yaml
+++ b/.github/workflows/build-rust-x86_64-apple-darwin-self-hosted-dispatch.yaml
@@ -74,7 +74,7 @@ jobs:
           submodules: true
       - name: Prepare build
         run: |
-          python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${{ github.event.inputs.release_version }}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --set rust.jemalloc --enable-lld
+          python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${{ github.event.inputs.release_version }}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --set rust.jemalloc --enable-lld
       - name: Build with x.py - dist packages
         run: python3 x.py dist --stage 2 || echo "Ignoring pkg failure"
       - name: Upload Release Asset

--- a/.github/workflows/build-rust-x86_64-pc-windows-gnu-self-hosted-dispatch.yaml
+++ b/.github/workflows/build-rust-x86_64-pc-windows-gnu-self-hosted-dispatch.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Prepare build
         working-directory: "R:"
         run: |
-          C:\msys64\usr\bin\env.exe MSYSTEM=MINGW64 /usr/bin/bash -lc "cd /r; python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description='${{ github.event.inputs.release_version }}' --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --enable-lld"
+          C:\msys64\usr\bin\env.exe MSYSTEM=MINGW64 /usr/bin/bash -lc "cd /r; python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description='${{ github.event.inputs.release_version }}' --enable-extended --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --enable-lld"
       - name: Build with x.py - dist packages
         id: build-rust
         working-directory: "R:"

--- a/.github/workflows/build-rust-x86_64-pc-windows-msvc-self-hosted-dispatch.yaml
+++ b/.github/workflows/build-rust-x86_64-pc-windows-msvc-self-hosted-dispatch.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Prepare build
         working-directory: "R:"
         run: |
-          python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${{ github.event.inputs.release_version }}" --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --enable-lld
+          python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${{ github.event.inputs.release_version }}" --enable-extended --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --enable-lld
       - name: Build with x.py - dist packages
         working-directory: "R:"
         continue-on-error: true

--- a/support/rust-build/aarch64-unknown-linux-gnu/build.sh
+++ b/support/rust-build/aarch64-unknown-linux-gnu/build.sh
@@ -4,5 +4,5 @@ set -e
 
 git clone --recursive --depth 1 --shallow-submodules https://github.com/esp-rs/rust.git
 cd rust
-python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${RELEASE_DESCRIPTION}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --enable-lld
+python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${RELEASE_DESCRIPTION}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --enable-lld
 python3 x.py dist --stage 2

--- a/support/rust-build/x86_64-pc-windows-gnu/build-rust-toolchain-msys2.sh
+++ b/support/rust-build/x86_64-pc-windows-gnu/build-rust-toolchain-msys2.sh
@@ -4,6 +4,6 @@ cd c:
 git clone --recursive --depth 1 --shallow-submodules https://github.com/esp-rs/rust.git r
 cd r
 
-python3 src/bootstrap/configure.py --experimental-targets=Xtensa --enable-extended --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --host 'x86_64-pc-windows-gnu' --enable-lld
+python3 src/bootstrap/configure.py --experimental-targets=Xtensa --enable-extended --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --host 'x86_64-pc-windows-gnu' --enable-lld
 
 python3 x.py dist --stage 2

--- a/support/rust-build/x86_64-unknown-linux-gnu/build.sh
+++ b/support/rust-build/x86_64-unknown-linux-gnu/build.sh
@@ -4,6 +4,6 @@ set -e
 
 git clone --recursive --depth 1 --shallow-submodules https://github.com/esp-rs/rust.git
 cd rust
-python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${RELEASE_DESCRIPTION}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt --dist-compression-formats='xz' --enable-lld
+python3 src/bootstrap/configure.py --experimental-targets=Xtensa --release-channel=nightly --release-description="${RELEASE_DESCRIPTION}" --enable-extended --enable-cargo-native-static --tools=clippy,cargo,rustfmt,rust-analyzer-proc-macro-srv --dist-compression-formats='xz' --enable-lld
 python3 x.py dist --stage 2
 


### PR DESCRIPTION
While #215 included `rust-analyzer-proc-macro-srv` for a few targets, the majority of targets did not receive this update. I have not run the build with these changes, so apologies if I've missed something here and these were omitted for a reason. But I believe this should all be okay.