### PR TITLE
Avoid using set-output

### DIFF
--- a/.github/workflows/build-aarch64-apple-darwin.yaml
+++ b/.github/workflows/build-aarch64-apple-darwin.yaml
@@ -29,7 +29,7 @@ jobs:
         id: get_upload_url
         run: |
           url=$(echo "$response" | jq -r '.upload_url')
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
         env:
           response: ${{ steps.get_release.outputs.data }}
 

--- a/.github/workflows/build-aarch64-unknown-linux-gnu.yaml
+++ b/.github/workflows/build-aarch64-unknown-linux-gnu.yaml
@@ -29,7 +29,7 @@ jobs:
         id: get_upload_url
         run: |
           url=$(echo "$response" | jq -r '.upload_url')
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
         env:
           response: ${{ steps.get_release.outputs.data }}
 

--- a/.github/workflows/build-rust-src.yaml
+++ b/.github/workflows/build-rust-src.yaml
@@ -29,7 +29,7 @@ jobs:
         id: get_upload_url
         run: |
           url=$(echo "$response" | jq -r '.upload_url')
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
         env:
           response: ${{ steps.get_release.outputs.data }}
 

--- a/.github/workflows/build-x86_64-apple-darwin.yaml
+++ b/.github/workflows/build-x86_64-apple-darwin.yaml
@@ -28,7 +28,7 @@ jobs:
         id: get_upload_url
         run: |
           url=$(echo "$response" | jq -r '.upload_url')
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
         env:
           response: ${{ steps.get_release.outputs.data }}
 

--- a/.github/workflows/build-x86_64-pc-windows-gnu.yaml
+++ b/.github/workflows/build-x86_64-pc-windows-gnu.yaml
@@ -29,7 +29,7 @@ jobs:
         id: get_upload_url
         run: |
           url=$(echo "$response" | jq -r '.upload_url')
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
         env:
           response: ${{ steps.get_release.outputs.data }}
 

--- a/.github/workflows/build-x86_64-pc-windows-msvc.yaml
+++ b/.github/workflows/build-x86_64-pc-windows-msvc.yaml
@@ -29,7 +29,7 @@ jobs:
         id: get_upload_url
         run: |
           url=$(echo "$response" | jq -r '.upload_url')
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
         env:
           response: ${{ steps.get_release.outputs.data }}
 

--- a/.github/workflows/build-x86_64-unknown-linux-gnu.yaml
+++ b/.github/workflows/build-x86_64-unknown-linux-gnu.yaml
@@ -28,7 +28,7 @@ jobs:
         id: get_upload_url
         run: |
           url=$(echo "$response" | jq -r '.upload_url')
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
         env:
           response: ${{ steps.get_release.outputs.data }}
 


### PR DESCRIPTION
It was generating a deprecation warning. More info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/