### PR TITLE
ci: update docs.esp-rs.org link to docs.espressif.com

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -23,7 +23,7 @@ jobs:
           body: |
             Rust Xtensa Toolchain ${{ github.event.inputs.next_release }} for ESP32, ESP32-S2, ESP32-S3.
 
-            Installation: https://docs.esp-rs.org/book/installation/riscv-and-xtensa.html
+            Installation: https://docs.espressif.com/projects/rust/book/getting-started/toolchain.html
 
             ```
             espup install --toolchain-version ${{ steps.findandreplace.outputs.value }}


### PR DESCRIPTION
The `docs.esp-rs.org` domain has expired and now points to unsafe content.
This PR updates the installation link in the release-notes body of `prepare-release.yaml` to the new toolchain installation page.

The replacement URL was verified to resolve (HTTP 200, follows redirects) before this PR was opened.

Note: the new book has been restructured and no longer has a single `riscv-and-xtensa.html` page; `book/getting-started/toolchain.html` is the closest equivalent landing page.

_Auto-generated as part of a coordinated link cleanup across `esp-rs`._